### PR TITLE
Add Ruby version to gem file for RVM dependency.

### DIFF
--- a/source/Gemfile
+++ b/source/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+ruby '2.0.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.6'


### PR DESCRIPTION
Adding Ruby version to Gemfile to fix version management issue with RVM.